### PR TITLE
Errors log for the entire application in errors folder instead of dumping to root.

### DIFF
--- a/MainWindow/MainWindow.cs
+++ b/MainWindow/MainWindow.cs
@@ -192,7 +192,15 @@ namespace FestivalInstrumentMapper
             HidHideConfigWindow configWindow = new();
             configWindow.ShowDialog(this);
         }
-
+        private void MainWindow_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            // is closing the user closing or no 
+            if (e.CloseReason == CloseReason.UserClosing)
+            {
+                // call application exit
+                Application.Exit();
+            }
+        }
         private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs args)
         {
             var exception = (Exception)args.ExceptionObject;

--- a/MainWindow/MapperThread.cs
+++ b/MainWindow/MapperThread.cs
@@ -1,3 +1,7 @@
+using System.IO;
+using System.Threading;
+using System;
+
 namespace FestivalInstrumentMapper
 {
     internal delegate void ToGipAction(ReadOnlySpan<byte> inputBuffer, Span<byte> gipBuffer);
@@ -76,13 +80,7 @@ namespace FestivalInstrumentMapper
             }
             catch (Exception ex)
             {
-                string errorFile = Program.WriteErrorFile(ex);
-                MessageBox.Show(
-                    $"Caught an unhandled mapping exception:\n\n{ex.GetFirstLine()}\n\nPlease send the error log '{errorFile}' to the devs.",
-                    "Mapping Error",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Warning
-                );
+                WriteErrorFile(ex); // Call the function to handle error
             }
             finally
             {
@@ -90,6 +88,30 @@ namespace FestivalInstrumentMapper
                 _device.Close();
                 _readThread = null;
             }
+        }
+
+        private void WriteErrorFile(Exception ex)
+        {
+            // Get the root directory of the application
+            string rootDirectory = AppDomain.CurrentDomain.BaseDirectory;
+
+            // Combine the root directory with the "errors" folder name
+            string errorFolderPath = Path.Combine(rootDirectory, "errors");
+
+            // Create the "errors" folder if it doesn't exist
+            if (!Directory.Exists(errorFolderPath))
+            {
+                Directory.CreateDirectory(errorFolderPath);
+            }
+
+            // Generate a unique file name for the error log
+            string errorFileName = $"error_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.log";
+
+            // Combine the error folder path with the error file name
+            string errorFilePath = Path.Combine(errorFolderPath, errorFileName);
+
+            // Write the exception details to the error file
+            File.WriteAllText(errorFilePath, ex.ToString());
         }
     }
 }

--- a/MainWindow/MapperThread.cs
+++ b/MainWindow/MapperThread.cs
@@ -92,25 +92,23 @@ namespace FestivalInstrumentMapper
 
         private void WriteErrorFile(Exception ex)
         {
-            // Get the root directory of the application
+            // get root
             string rootDirectory = AppDomain.CurrentDomain.BaseDirectory;
 
-            // Combine the root directory with the "errors" folder name
             string errorFolderPath = Path.Combine(rootDirectory, "errors");
 
-            // Create the "errors" folder if it doesn't exist
+            //  makes error folder if its not there
             if (!Directory.Exists(errorFolderPath))
             {
                 Directory.CreateDirectory(errorFolderPath);
             }
 
-            // Generate a unique file name for the error log
+            // generate error name
             string errorFileName = $"error_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.log";
 
-            // Combine the error folder path with the error file name
             string errorFilePath = Path.Combine(errorFolderPath, errorFileName);
 
-            // Write the exception details to the error file
+            // write exception details
             File.WriteAllText(errorFilePath, ex.ToString());
         }
     }

--- a/MainWindow/MapperThread.cs
+++ b/MainWindow/MapperThread.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using System.Threading;
 using System;
 
@@ -80,7 +79,13 @@ namespace FestivalInstrumentMapper
             }
             catch (Exception ex)
             {
-                WriteErrorFile(ex); // Call the function to handle error
+                string errorFile = Program.WriteErrorFile(ex);
+                MessageBox.Show(
+                    $"Caught an unhandled mapping exception:\n\n{ex.GetFirstLine()}\n\nPlease send the error log '{errorFile}' to the devs.",
+                    "Mapping Error",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning
+                );
             }
             finally
             {
@@ -88,28 +93,6 @@ namespace FestivalInstrumentMapper
                 _device.Close();
                 _readThread = null;
             }
-        }
-
-        private void WriteErrorFile(Exception ex)
-        {
-            // get root
-            string rootDirectory = AppDomain.CurrentDomain.BaseDirectory;
-
-            string errorFolderPath = Path.Combine(rootDirectory, "errors");
-
-            //  makes error folder if its not there
-            if (!Directory.Exists(errorFolderPath))
-            {
-                Directory.CreateDirectory(errorFolderPath);
-            }
-
-            // generate error name
-            string errorFileName = $"error_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.log";
-
-            string errorFilePath = Path.Combine(errorFolderPath, errorFileName);
-
-            // write exception details
-            File.WriteAllText(errorFilePath, ex.ToString());
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,9 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Windows.Forms;
+
 namespace FestivalInstrumentMapper
 {
     internal static class Program
@@ -22,9 +28,48 @@ namespace FestivalInstrumentMapper
 
         public static string WriteErrorFile(Exception ex)
         {
-            string fileName = $"error_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.txt";
-            File.WriteAllText(fileName, ex.ToString());
-            return fileName;
+            // get root directory
+            string rootDirectory = AppDomain.CurrentDomain.BaseDirectory;
+
+            // combine roon with errors folder
+            string errorFolderPath = Path.Combine(rootDirectory, "errors");
+
+            // create errors folder if its not there
+            if (!Directory.Exists(errorFolderPath))
+            {
+                Directory.CreateDirectory(errorFolderPath);
+            }
+
+            // generate error file name 
+            string errorFileName = $"error_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.txt";
+
+            // combine erros path with the errors file name 
+            string errorFilePath = Path.Combine(errorFolderPath, errorFileName);
+
+            // write the errors details to the error file 
+            File.WriteAllText(errorFilePath, ex.ToString());
+
+            // display the error in the box 
+            string errorMessage = $"Caught an unhandled mapping exception:\n\n{ex}\n\nError log saved to:\n{errorFilePath}";
+            MessageBox.Show(
+                errorMessage,
+                "Mapping Error",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Warning
+            );
+
+            // open the errors folder
+            if (Directory.Exists(errorFolderPath))
+            {
+                Process.Start("explorer.exe", errorFolderPath);
+            }
+            else
+            {
+                MessageBox.Show("Error folder does not exist.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+
+            // return file path 
+            return errorFilePath;
         }
     }
 }


### PR DESCRIPTION
took the existing function, made it universal. also fixed another issue, application sticking around in task manager. not sure if that was something i messed up on accident. but nonetheless the app now actually closes. also reverted mapperthread back to the reference file